### PR TITLE
fix(mixstatus): suppress duplicate nowPlaying on cue-juggle replay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,6 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: alphatheta-connect
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,7 +18,26 @@ jobs:
           repository: chrisle/onelibrary-connect
           path: onelibrary-connect
       - uses: volta-cli/action@v4
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn test
-      - run: yarn build
+        with:
+          package-json-path: alphatheta-connect/package.json
+
+      - name: Build metadata-connect
+        working-directory: metadata-connect
+        run: npm install && npm run build
+
+      - name: Build onelibrary-connect
+        working-directory: onelibrary-connect
+        run: npm install && npm run build
+
+      - name: Install alphatheta-connect
+        working-directory: alphatheta-connect
+        run: yarn install
+      - name: Lint
+        working-directory: alphatheta-connect
+        run: yarn lint
+      - name: Test
+        working-directory: alphatheta-connect
+        run: yarn test
+      - name: Build
+        working-directory: alphatheta-connect
+        run: yarn build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,15 +29,19 @@ jobs:
         working-directory: onelibrary-connect
         run: npm install && npm run build
 
+      # Use npm so file:../onelibrary-connect installs as a symlink. yarn
+      # copies the dep tree, which produces two copies of
+      # better-sqlite3-multiple-ciphers (one at the top level, one nested under
+      # onelibrary-connect) and breaks the native module self-register.
       - name: Install alphatheta-connect
         working-directory: alphatheta-connect
-        run: yarn install
+        run: npm ci
       - name: Lint
         working-directory: alphatheta-connect
-        run: yarn lint
+        run: npm run lint
       - name: Test
         working-directory: alphatheta-connect
-        run: yarn test
+        run: npm test
       - name: Build
         working-directory: alphatheta-connect
-        run: yarn build
+        run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,15 @@ jobs:
         with:
           repository: chrisle/onelibrary-connect
           path: onelibrary-connect
-      - uses: volta-cli/action@v4
+      # Set Node globally (not via volta) so the sibling onelibrary-connect
+      # build runs on the same version as alphatheta-connect's tests.
+      # volta only activates inside a directory whose package.json pins it,
+      # so onelibrary-connect/`npm install` was building better-sqlite3 against
+      # the runner's default Node and the resulting binary couldn't load under
+      # the pinned Node when alphatheta-connect's tests ran.
+      - uses: actions/setup-node@v4
         with:
-          package-json-path: alphatheta-connect/package.json
+          node-version: '22.13.0'
 
       - name: Build metadata-connect
         working-directory: metadata-connect

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,21 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: alphatheta-connect
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: alphatheta-connect
+      - uses: actions/checkout@v4
+        with:
+          repository: chrisle/metadata-connect
+          path: metadata-connect
+      - uses: actions/checkout@v4
+        with:
+          repository: chrisle/onelibrary-connect
+          path: onelibrary-connect
       - uses: volta-cli/action@v4
       - run: yarn install
       - run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,27 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: alphatheta-connect
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: alphatheta-connect
+
+      - name: Checkout metadata-connect
+        uses: actions/checkout@v4
+        with:
+          repository: chrisle/metadata-connect
+          path: metadata-connect
+
+      - name: Checkout onelibrary-connect
+        uses: actions/checkout@v4
+        with:
+          repository: chrisle/onelibrary-connect
+          path: onelibrary-connect
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: alphatheta-connect
 
     steps:
       - name: Checkout
@@ -37,13 +34,24 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.13.0'
+
+      - name: Build metadata-connect
+        working-directory: metadata-connect
+        run: npm install && npm run build
+
+      - name: Build onelibrary-connect
+        working-directory: onelibrary-connect
+        run: npm install && npm run build
 
       - name: Install dependencies
+        working-directory: alphatheta-connect
         run: npm ci
 
       - name: Run tests
+        working-directory: alphatheta-connect
         run: npm test
 
       - name: Build
+        working-directory: alphatheta-connect
         run: npm run build

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,7 +10,10 @@ const config = {
   },
   transform: {
     '^.+\\.tsx?$': ['ts-jest'],
-    'node_modules/onelibrary-connect/.+\\.js$': ['ts-jest', {useESM: false}],
+    // Match onelibrary-connect whether it's under node_modules or resolved as
+    // a sibling dir (npm `file:` deps install as symlinks; Jest sees the
+    // realpath, which has no node_modules prefix in CI).
+    '[/\\\\]onelibrary-connect[/\\\\].+\\.js$': ['ts-jest', {useESM: false}],
   },
   transformIgnorePatterns: [
     'node_modules/(?!onelibrary-connect)',

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "serialize-javascript": ">=7.0.3"
   },
   "volta": {
-    "node": "22.11.0",
+    "node": "22.13.0",
     "yarn": "1.22.22"
   }
 }

--- a/src/artwork/index.ts
+++ b/src/artwork/index.ts
@@ -58,11 +58,15 @@ export async function extractArtworkFromDevice(
   filePath: string,
   logger: Logger = noopLogger
 ): Promise<ExtractedArtwork | null> {
-  logger.debug(`[artwork-nfs] getFileInfo: device=${device.ip.address}, slot=${slot}, path=${filePath}`);
+  logger.debug(
+    `[artwork-nfs] getFileInfo: device=${device.ip.address}, slot=${slot}, path=${filePath}`
+  );
   const fileInfo = await getFileInfo({device, slot, path: filePath});
   logger.debug(`[artwork-nfs] File found: ${fileInfo.size} bytes`);
   const reader = createNfsFileReader(device, slot, filePath, fileInfo.size);
   const result = await extractArtwork(reader);
-  logger.debug(`[artwork-nfs] extractArtwork result: ${result ? `${result.mimeType} (${result.data.length}b)` : 'null'}`);
+  logger.debug(
+    `[artwork-nfs] extractArtwork result: ${result ? `${result.mimeType} (${result.data.length}b)` : 'null'}`
+  );
   return result;
 }

--- a/src/db/getArtworkFromFile.ts
+++ b/src/db/getArtworkFromFile.ts
@@ -45,7 +45,9 @@ export async function viaFileExtraction(
 
   const extension = track.filePath.split('.').pop()?.toLowerCase() ?? '';
   if (!isArtworkExtractionSupported(extension)) {
-    logger.debug(`[artwork-nfs] Skipping: unsupported extension ".${extension}" (${track.filePath})`);
+    logger.debug(
+      `[artwork-nfs] Skipping: unsupported extension ".${extension}" (${track.filePath})`
+    );
     return null;
   }
 

--- a/src/db/getFile.ts
+++ b/src/db/getFile.ts
@@ -1,6 +1,6 @@
 import {Track} from 'src/entities';
-import {type Logger, noopLogger} from 'src/logger';
 import LocalDatabase from 'src/localdb';
+import {type Logger, noopLogger} from 'src/logger';
 import {fetchFile} from 'src/nfs';
 import RemoteDatabase from 'src/remotedb';
 import {Device, DeviceID, MediaSlot, TrackType} from 'src/types';
@@ -68,11 +68,7 @@ export function viaRemote(
   // });
 }
 
-export async function viaLocal(
-  local: LocalDatabase,
-  device: Device,
-  opts: Options
-) {
+export async function viaLocal(local: LocalDatabase, device: Device, opts: Options) {
   const {deviceId, trackSlot, track} = opts;
   const logger = opts.logger ?? noopLogger;
 

--- a/src/db/getTrackAnalysis.ts
+++ b/src/db/getTrackAnalysis.ts
@@ -1,7 +1,18 @@
 import {Track} from 'src/entities';
 import LocalDatabase from 'src/localdb';
 import {loadAnlz} from 'src/localdb/rekordbox';
-import {Device, DeviceID, ExtendedCue, MediaSlot, SongStructure, TrackType, VocalConfig, Waveform3BandDetail, Waveform3BandPreview, WaveformHD} from 'src/types';
+import {
+  Device,
+  DeviceID,
+  ExtendedCue,
+  MediaSlot,
+  SongStructure,
+  TrackType,
+  VocalConfig,
+  Waveform3BandDetail,
+  Waveform3BandPreview,
+  WaveformHD,
+} from 'src/types';
 import {TelemetrySpan as Span} from 'src/utils/telemetry';
 
 import {anlzLoader} from './utils';

--- a/src/db/getWaveforms.ts
+++ b/src/db/getWaveforms.ts
@@ -2,7 +2,15 @@ import {Track} from 'src/entities';
 import LocalDatabase from 'src/localdb';
 import {loadAnlz} from 'src/localdb/rekordbox';
 import RemoteDatabase, {MenuTarget, Query} from 'src/remotedb';
-import {Device, DeviceID, MediaSlot, TrackType, Waveforms, WaveformDetailed, WaveformPreview} from 'src/types';
+import {
+  Device,
+  DeviceID,
+  MediaSlot,
+  TrackType,
+  WaveformDetailed,
+  WaveformPreview,
+  Waveforms,
+} from 'src/types';
 import {TelemetrySpan as Span} from 'src/utils/telemetry';
 
 import {anlzLoader} from './utils';

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -47,12 +47,10 @@ class Database {
   #remoteDatabase: RemoteDatabase;
 
   constructor(
-    hostDevice: Device,
     local: LocalDatabase,
     remote: RemoteDatabase,
     deviceManager: DeviceManager
   ) {
-    this.#hostDevice = hostDevice;
     this.#localDatabase = local;
     this.#remoteDatabase = remote;
     this.#deviceManager = deviceManager;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -34,7 +34,6 @@ enum LookupStrategy {
  * network for information from their databases.
  */
 class Database {
-  #hostDevice: Device;
   #deviceManager: DeviceManager;
   /**
    * The local database service, used when querying media devices connected

--- a/src/localdb/index.ts
+++ b/src/localdb/index.ts
@@ -1,4 +1,10 @@
 import {Mutex} from 'async-mutex';
+import {
+  type DatabaseAdapter,
+  type DatabasePreference,
+  type DatabaseType,
+  OneLibraryAdapter,
+} from 'onelibrary-connect';
 import StrictEventEmitter from 'strict-event-emitter-types';
 
 import {createHash} from 'crypto';
@@ -7,8 +13,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import DeviceManager from 'src/devices';
 import {MAX_CDJ_DEVICE_ID, MIN_CDJ_DEVICE_ID} from 'src/constants';
+import DeviceManager from 'src/devices';
 import {fetchFile, FetchProgress} from 'src/nfs';
 import StatusEmitter from 'src/status';
 import {
@@ -22,12 +28,6 @@ import {
 import {getSlotName} from 'src/utils';
 import * as Telemetry from 'src/utils/telemetry';
 
-import {
-  type DatabaseAdapter,
-  type DatabasePreference,
-  type DatabaseType,
-  OneLibraryAdapter,
-} from 'onelibrary-connect';
 import {MetadataORM} from './orm';
 import {hydrateDatabase, HydrationProgress} from './rekordbox';
 
@@ -225,7 +225,9 @@ class LocalDatabase {
     tx: Telemetry.TelemetrySpan
   ): Promise<Buffer> => {
     const attemptOrder =
-      process.platform === 'win32' ? [basePath, `.${basePath}`] : [`.${basePath}`, basePath];
+      process.platform === 'win32'
+        ? [basePath, `.${basePath}`]
+        : [`.${basePath}`, basePath];
 
     try {
       return await fetchFile({
@@ -233,15 +235,17 @@ class LocalDatabase {
         slot,
         path: attemptOrder[0],
         span: tx,
-        onProgress: progress => this.#emitter.emit('fetchProgress', {device, slot, progress}),
+        onProgress: progress =>
+          this.#emitter.emit('fetchProgress', {device, slot, progress}),
       });
     } catch {
-      return await fetchFile({
+      return fetchFile({
         device,
         slot,
         path: attemptOrder[1],
         span: tx,
-        onProgress: progress => this.#emitter.emit('fetchProgress', {device, slot, progress}),
+        onProgress: progress =>
+          this.#emitter.emit('fetchProgress', {device, slot, progress}),
       });
     }
   };
@@ -262,7 +266,10 @@ class LocalDatabase {
 
       // Write to temp file (OneLibrary requires file path for SQLCipher)
       const tempDir = os.tmpdir();
-      const tempFile = path.join(tempDir, `prolink-onelibrary-${device.id}-${slot}-${Date.now()}.db`);
+      const tempFile = path.join(
+        tempDir,
+        `prolink-onelibrary-${device.id}-${slot}-${Date.now()}.db`
+      );
       fs.writeFileSync(tempFile, dbData);
 
       const adapter = new OneLibraryAdapter(tempFile);
@@ -292,7 +299,8 @@ class LocalDatabase {
       orm,
       pdbData,
       span: tx,
-      onProgress: progress => this.#emitter.emit('hydrationProgress', {device, slot, progress}),
+      onProgress: progress =>
+        this.#emitter.emit('hydrationProgress', {device, slot, progress}),
     });
 
     return orm;
@@ -323,7 +331,9 @@ class LocalDatabase {
       // OneLibrary only
       const oneLibraryResult = await this.#tryLoadOneLibrary(device, slot, tx);
       if (!oneLibraryResult) {
-        throw new Error('OneLibrary database not found and preference is set to oneLibrary only');
+        throw new Error(
+          'OneLibrary database not found and preference is set to oneLibrary only'
+        );
       }
       adapter = oneLibraryResult.adapter;
       tempFile = oneLibraryResult.tempFile;
@@ -371,7 +381,11 @@ class LocalDatabase {
       return null;
     }
 
-    if (device.type !== DeviceType.CDJ || device.id < MIN_CDJ_DEVICE_ID || device.id > MAX_CDJ_DEVICE_ID) {
+    if (
+      device.type !== DeviceType.CDJ ||
+      device.id < MIN_CDJ_DEVICE_ID ||
+      device.id > MAX_CDJ_DEVICE_ID
+    ) {
       return null;
     }
 
@@ -423,7 +437,10 @@ class LocalDatabase {
   async preload() {
     const allDevices = [...this.#deviceManager.devices.values()];
     const cdjDevices = allDevices.filter(
-      device => device.type === DeviceType.CDJ && device.id >= MIN_CDJ_DEVICE_ID && device.id <= MAX_CDJ_DEVICE_ID
+      device =>
+        device.type === DeviceType.CDJ &&
+        device.id >= MIN_CDJ_DEVICE_ID &&
+        device.id <= MAX_CDJ_DEVICE_ID
     );
 
     if (cdjDevices.length === 0) {

--- a/src/localdb/onelibrary.ts
+++ b/src/localdb/onelibrary.ts
@@ -4,12 +4,6 @@
  * Re-exports from onelibrary-connect for backward compatibility.
  */
 
-export {
-  getEncryptionKey,
-  openOneLibraryDb,
-  OneLibraryAdapter,
-} from 'onelibrary-connect';
-
 export type {
   Category,
   DeviceProperty,
@@ -19,3 +13,4 @@ export type {
   MyTag,
   SortOption,
 } from 'onelibrary-connect';
+export {getEncryptionKey, OneLibraryAdapter, openOneLibraryDb} from 'onelibrary-connect';

--- a/src/localdb/rekordbox.ts
+++ b/src/localdb/rekordbox.ts
@@ -5,8 +5,6 @@
  * @see ./rekordbox/index.ts for the implementation
  */
 
-export {hydrateDatabase, loadAnlz} from './rekordbox/index';
-
 export type {
   AnlzResolver,
   AnlzResponse,
@@ -16,3 +14,4 @@ export type {
   HydrationOptions,
   HydrationProgress,
 } from './rekordbox/index';
+export {hydrateDatabase, loadAnlz} from './rekordbox/index';

--- a/src/mixstatus/index.ts
+++ b/src/mixstatus/index.ts
@@ -123,6 +123,14 @@ export class MixstatusProcessor {
    */
   #livePlayers = new Set<DeviceID>();
   /**
+   * Records the last trackId emitted as 'nowPlaying' for each device. Used to
+   * suppress duplicate emissions when a deck is briefly cued/loaded and then
+   * resumed on the same track (a common pattern for House/Techno DJs who
+   * cue-juggle mid-track). The entry is replaced when a different trackId is
+   * emitted on the same deck, so subsequent track loads still emit normally.
+   */
+  #lastEmittedTrackId = new Map<DeviceID, number>();
+  /**
    * Incidates if we're currentiny in an active DJ set
    */
   #isSetActive = false;
@@ -175,6 +183,15 @@ export class MixstatusProcessor {
       return;
     }
 
+    // Suppress duplicate nowPlaying for the same track on the same deck. This
+    // can happen when a DJ cues mid-track and resumes (Cued/Loading/Ended are
+    // all stoppingStates that drop the deck from livePlayers, so the next play
+    // of the same trackId would otherwise re-emit). When a different track is
+    // loaded, the trackId differs and the new emission proceeds normally.
+    if (this.#lastEmittedTrackId.get(deviceId) === state.trackId) {
+      return;
+    }
+
     if (!this.#isSetActive) {
       this.#isSetActive = true;
       this.#emitter.emit('setStarted');
@@ -185,6 +202,7 @@ export class MixstatusProcessor {
     }
 
     this.#livePlayers.add(deviceId);
+    this.#lastEmittedTrackId.set(deviceId, state.trackId);
 
     this.#emitter.emit('nowPlaying', state);
   };

--- a/src/network.ts
+++ b/src/network.ts
@@ -303,7 +303,7 @@ export class ProlinkNetwork {
     );
 
     // Create unified database
-    const database = new Database(vcdj, localdb, remotedb, this.#deviceManager);
+    const database = new Database(localdb, remotedb, this.#deviceManager);
 
     // Create controller service
     const control = new Control(this.#beatSocket, vcdj);

--- a/src/nfs/index.test.ts
+++ b/src/nfs/index.test.ts
@@ -42,7 +42,9 @@ describe('parseWindowsPath', () => {
   });
 
   it('converts all backslashes to forward slashes', () => {
-    const result = parseWindowsPath('C:\\Users\\chris\\Music\\PioneerDJ\\Imported from Device\\Contents\\track.mp3');
+    const result = parseWindowsPath(
+      'C:\\Users\\chris\\Music\\PioneerDJ\\Imported from Device\\Contents\\track.mp3'
+    );
     expect(result).toEqual({
       mountPath: '/C/',
       nfsPath: 'Users/chris/Music/PioneerDJ/Imported from Device/Contents/track.mp3',
@@ -72,10 +74,7 @@ describe('resolveNfsPath', () => {
     });
 
     it('resolves Windows backslash path to NFS mount and path', () => {
-      const result = resolveNfsPath(
-        MediaSlot.RB,
-        'C:\\Users\\chris\\Music\\track.mp3'
-      );
+      const result = resolveNfsPath(MediaSlot.RB, 'C:\\Users\\chris\\Music\\track.mp3');
       expect(result).toEqual({
         mountPath: '/C/',
         nfsPath: 'Users/chris/Music/track.mp3',
@@ -83,10 +82,7 @@ describe('resolveNfsPath', () => {
     });
 
     it('resolves macOS absolute path', () => {
-      const result = resolveNfsPath(
-        MediaSlot.RB,
-        '/Users/chris/Music/track.mp3'
-      );
+      const result = resolveNfsPath(MediaSlot.RB, '/Users/chris/Music/track.mp3');
       expect(result).toEqual({
         mountPath: '/',
         nfsPath: 'Users/chris/Music/track.mp3',
@@ -96,10 +92,7 @@ describe('resolveNfsPath', () => {
 
   describe('USB slot', () => {
     it('uses /C/ mount for USB slot', () => {
-      const result = resolveNfsPath(
-        MediaSlot.USB,
-        'PIONEER/USBANLZ/track.mp3'
-      );
+      const result = resolveNfsPath(MediaSlot.USB, 'PIONEER/USBANLZ/track.mp3');
       expect(result).toEqual({
         mountPath: '/C/',
         nfsPath: 'PIONEER/USBANLZ/track.mp3',
@@ -109,10 +102,7 @@ describe('resolveNfsPath', () => {
 
   describe('SD slot', () => {
     it('uses /B/ mount for SD slot', () => {
-      const result = resolveNfsPath(
-        MediaSlot.SD,
-        'PIONEER/USBANLZ/track.mp3'
-      );
+      const result = resolveNfsPath(MediaSlot.SD, 'PIONEER/USBANLZ/track.mp3');
       expect(result).toEqual({
         mountPath: '/B/',
         nfsPath: 'PIONEER/USBANLZ/track.mp3',

--- a/src/nfs/index.ts
+++ b/src/nfs/index.ts
@@ -49,9 +49,13 @@ export type NfsMediaSlot = MediaSlot.USB | MediaSlot.SD | MediaSlot.RB;
  *
  * @internal Exported for testing
  */
-export function parseWindowsPath(filePath: string): {mountPath: string; nfsPath: string} | null {
+export function parseWindowsPath(
+  filePath: string
+): {mountPath: string; nfsPath: string} | null {
   const match = filePath.match(/^([A-Za-z]):[/\\](.*)$/);
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   return {
     mountPath: `/${match[1].toUpperCase()}/`,
     nfsPath: match[2].replace(/\\/g, '/'),
@@ -76,7 +80,9 @@ export function resolveNfsPath(
   if (slot === MediaSlot.RB) {
     // Windows: C:\Users\chris\Music\track.mp3 → mount /C/, path Users/...
     const parsed = parseWindowsPath(filePath);
-    if (parsed) return parsed;
+    if (parsed) {
+      return parsed;
+    }
 
     // macOS: /Users/chris/Music/track.mp3 → mount /, path Users/...
     if (filePath.startsWith('/')) {
@@ -140,15 +146,23 @@ async function getClients(device: Device) {
   const conn = new RpcConnection(address, retryConfig);
   const portmapPort = getPortmapPort(device);
 
-  const mountClient = await makeProgramClient(conn, {
-    id: mount.Program,
-    version: mount.Version,
-  }, portmapPort);
+  const mountClient = await makeProgramClient(
+    conn,
+    {
+      id: mount.Program,
+      version: mount.Version,
+    },
+    portmapPort
+  );
 
-  const nfsClient = await makeProgramClient(conn, {
-    id: nfs.Program,
-    version: nfs.Version,
-  }, portmapPort);
+  const nfsClient = await makeProgramClient(
+    conn,
+    {
+      id: nfs.Program,
+      version: nfs.Version,
+    },
+    portmapPort
+  );
 
   const set = {conn, mountClient, nfsClient};
   clientsCache.set(address, set);
@@ -178,7 +192,12 @@ const rootHandleCache = new Map<string, Map<string, Buffer>>();
  *       verify this). It is up to the caller to clear the cache and get the
  *       new root handle in that case.
  */
-async function getRootHandle({device, mountPath, mountClient, span}: GetRootHandleOptions) {
+async function getRootHandle({
+  device,
+  mountPath,
+  mountClient,
+  span,
+}: GetRootHandleOptions) {
   const tx = span?.startChild({op: 'getRootHandle'});
 
   const {address} = device.ip;

--- a/src/passive/alphatheta.ts
+++ b/src/passive/alphatheta.ts
@@ -143,16 +143,8 @@ export function findAllAlphaThetaInterfaces(): AlphaThetaInterface[] {
 }
 
 /**
- * macOS implementation: Uses ioreg to find AlphaTheta USB devices,
- * then networksetup to map them to interface names.
- */
-function findAlphaThetaInterfaceMacOS(): AlphaThetaInterface | null {
-  const results = findAllAlphaThetaInterfacesMacOS();
-  return results.length > 0 ? results[0] : null;
-}
-
-/**
- * macOS implementation: Find ALL AlphaTheta USB interfaces.
+ * macOS implementation: Find ALL AlphaTheta USB interfaces using ioreg
+ * and networksetup to map them to interface names.
  */
 function findAllAlphaThetaInterfacesMacOS(): AlphaThetaInterface[] {
   try {
@@ -240,15 +232,7 @@ function findAllAlphaThetaInterfacesMacOS(): AlphaThetaInterface[] {
 }
 
 /**
- * Windows implementation: Uses PowerShell to find AlphaTheta USB network adapters.
- */
-function findAlphaThetaInterfaceWindows(): AlphaThetaInterface | null {
-  const results = findAllAlphaThetaInterfacesWindows();
-  return results.length > 0 ? results[0] : null;
-}
-
-/**
- * Windows implementation: Find ALL AlphaTheta USB interfaces.
+ * Windows implementation: Find ALL AlphaTheta USB network adapters via PowerShell.
  */
 function findAllAlphaThetaInterfacesWindows(): AlphaThetaInterface[] {
   try {
@@ -453,15 +437,6 @@ function getAlphaThetaArpEntries(): Map<string, Array<{ip: string; mac: string}>
   }
 
   return result;
-}
-
-/**
- * Find an AlphaTheta device connected via Ethernet by checking the ARP cache
- * for known MAC address prefixes.
- */
-function findAlphaThetaViaEthernet(): AlphaThetaInterface | null {
-  const results = findAllAlphaThetaViaEthernet();
-  return results.length > 0 ? results[0] : null;
 }
 
 /**

--- a/src/passive/index.ts
+++ b/src/passive/index.ts
@@ -12,8 +12,8 @@ import {PassiveStatusEmitter} from './status';
 
 export {
   AlphaThetaInterface,
-  findAlphaThetaInterface,
   findAllAlphaThetaInterfaces,
+  findAlphaThetaInterface,
   getArpCacheForInterface,
 } from './alphatheta';
 export {PassiveDeviceManager} from './devices';

--- a/src/passive/localdb.ts
+++ b/src/passive/localdb.ts
@@ -233,7 +233,9 @@ export class PassiveLocalDatabase {
     tx: Telemetry.TelemetrySpan
   ): Promise<Buffer> => {
     const attemptOrder =
-      process.platform === 'win32' ? [basePath, `.${basePath}`] : [`.${basePath}`, basePath];
+      process.platform === 'win32'
+        ? [basePath, `.${basePath}`]
+        : [`.${basePath}`, basePath];
 
     try {
       return await fetchFile({
@@ -241,15 +243,17 @@ export class PassiveLocalDatabase {
         slot,
         path: attemptOrder[0],
         span: tx,
-        onProgress: progress => this.#emitter.emit('fetchProgress', {device, slot, progress}),
+        onProgress: progress =>
+          this.#emitter.emit('fetchProgress', {device, slot, progress}),
       });
     } catch {
-      return await fetchFile({
+      return fetchFile({
         device,
         slot,
         path: attemptOrder[1],
         span: tx,
-        onProgress: progress => this.#emitter.emit('fetchProgress', {device, slot, progress}),
+        onProgress: progress =>
+          this.#emitter.emit('fetchProgress', {device, slot, progress}),
       });
     }
   };
@@ -268,7 +272,10 @@ export class PassiveLocalDatabase {
       const dbData = await this.#fetchFileWithFallback(device, slot, oneLibraryPath, tx);
 
       const tempDir = os.tmpdir();
-      const tempFile = path.join(tempDir, `prolink-onelibrary-${device.id}-${slot}-${Date.now()}.db`);
+      const tempFile = path.join(
+        tempDir,
+        `prolink-onelibrary-${device.id}-${slot}-${Date.now()}.db`
+      );
       fs.writeFileSync(tempFile, dbData);
 
       const adapter = new OneLibraryAdapter(tempFile);
@@ -297,7 +304,8 @@ export class PassiveLocalDatabase {
       orm,
       pdbData,
       span: tx,
-      onProgress: progress => this.#emitter.emit('hydrationProgress', {device, slot, progress}),
+      onProgress: progress =>
+        this.#emitter.emit('hydrationProgress', {device, slot, progress}),
     });
 
     return orm;
@@ -319,7 +327,9 @@ export class PassiveLocalDatabase {
     } else if (this.#preference === 'oneLibrary') {
       const oneLibraryResult = await this.#tryLoadOneLibrary(device, slot, tx);
       if (!oneLibraryResult) {
-        throw new Error('OneLibrary database not found and preference is set to oneLibrary only');
+        throw new Error(
+          'OneLibrary database not found and preference is set to oneLibrary only'
+        );
       }
       adapter = oneLibraryResult.adapter;
       tempFile = oneLibraryResult.tempFile;
@@ -395,7 +405,11 @@ export class PassiveLocalDatabase {
       this.#slotLocks.get(lockKey) ??
       this.#slotLocks.set(lockKey, new Mutex()).get(lockKey)!;
 
-    if (device.type !== DeviceType.CDJ || device.id < MIN_CDJ_DEVICE_ID || device.id > MAX_CDJ_DEVICE_ID) {
+    if (
+      device.type !== DeviceType.CDJ ||
+      device.id < MIN_CDJ_DEVICE_ID ||
+      device.id > MAX_CDJ_DEVICE_ID
+    ) {
       return null;
     }
 
@@ -432,7 +446,11 @@ export class PassiveLocalDatabase {
       this.#slotLocks.get(lockKey) ??
       this.#slotLocks.set(lockKey, new Mutex()).get(lockKey)!;
 
-    if (device.type !== DeviceType.CDJ || device.id < MIN_CDJ_DEVICE_ID || device.id > MAX_CDJ_DEVICE_ID) {
+    if (
+      device.type !== DeviceType.CDJ ||
+      device.id < MIN_CDJ_DEVICE_ID ||
+      device.id > MAX_CDJ_DEVICE_ID
+    ) {
       return null;
     }
 
@@ -485,7 +503,10 @@ export class PassiveLocalDatabase {
   async preload() {
     const allDevices = [...this.#deviceManager.devices.values()];
     const cdjDevices = allDevices.filter(
-      device => device.type === DeviceType.CDJ && device.id >= MIN_CDJ_DEVICE_ID && device.id <= MAX_CDJ_DEVICE_ID
+      device =>
+        device.type === DeviceType.CDJ &&
+        device.id >= MIN_CDJ_DEVICE_ID &&
+        device.id <= MAX_CDJ_DEVICE_ID
     );
 
     if (cdjDevices.length === 0) {

--- a/src/remotedb/index.ts
+++ b/src/remotedb/index.ts
@@ -224,7 +224,9 @@ export default class RemoteDatabase {
     // Set a connection timeout to prevent hanging forever
     (socket.stream as Socket).setTimeout(10_000);
     (socket.stream as Socket).once('timeout', () => {
-      (socket.stream as Socket).destroy(new Error(`RemoteDB connection to ${ip.address}:${dbPort} timed out`));
+      (socket.stream as Socket).destroy(
+        new Error(`RemoteDB connection to ${ip.address}:${dbPort} timed out`)
+      );
     });
 
     await socket.connect(dbPort, ip.address);

--- a/src/virtualcdj/index.ts
+++ b/src/virtualcdj/index.ts
@@ -356,9 +356,15 @@ export class Announcer {
    * Resolves immediately if fullStartup is disabled.
    */
   get ready(): Promise<void> {
-    if (!this.#fullStartup) return Promise.resolve();
-    if (this.#currentStage === StartupStage.KeepAlive) return Promise.resolve();
-    return new Promise(resolve => { this.#onStartupComplete = resolve; });
+    if (!this.#fullStartup) {
+      return Promise.resolve();
+    }
+    if (this.#currentStage === StartupStage.KeepAlive) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      this.#onStartupComplete = resolve;
+    });
   }
 
   start() {

--- a/tests/db/getWaveforms.spec.ts
+++ b/tests/db/getWaveforms.spec.ts
@@ -16,9 +16,15 @@ const mockWaveformDetailed = [{height: 8, whiteness: 0.2}];
 function makeConn() {
   return {
     query: jest.fn((opts: any) => {
-      if (opts.query === 0x2c04) return Promise.resolve(mockWaveformHd);      // GetWaveformHD
-      if (opts.query === 0x2004) return Promise.resolve(mockWaveformPreview); // GetWaveformPreview
-      if (opts.query === 0x2904) return Promise.resolve(mockWaveformDetailed); // GetWaveformDetailed
+      if (opts.query === 0x2c04) {
+        return Promise.resolve(mockWaveformHd);
+      } // GetWaveformHD
+      if (opts.query === 0x2004) {
+        return Promise.resolve(mockWaveformPreview);
+      } // GetWaveformPreview
+      if (opts.query === 0x2904) {
+        return Promise.resolve(mockWaveformDetailed);
+      } // GetWaveformDetailed
       return Promise.resolve(null);
     }),
   };
@@ -96,9 +102,13 @@ describe('getWaveforms.viaRemote', () => {
       const conn = {
         query: jest.fn((opts: any) => {
           order.push(opts.query);
-          return Promise.resolve(opts.query === 0x2c04 ? mockWaveformHd
-            : opts.query === 0x2004 ? mockWaveformPreview
-            : mockWaveformDetailed);
+          return Promise.resolve(
+            opts.query === 0x2c04
+              ? mockWaveformHd
+              : opts.query === 0x2004
+                ? mockWaveformPreview
+                : mockWaveformDetailed
+          );
         }),
       };
 

--- a/tests/localdb/anlz-2ex-integration.spec.ts
+++ b/tests/localdb/anlz-2ex-integration.spec.ts
@@ -12,17 +12,12 @@
  */
 
 import {
-  makeWaveform3BandPreview,
-  makeWaveform3BandDetail,
   makeVocalConfig,
+  makeWaveform3BandDetail,
+  makeWaveform3BandPreview,
 } from 'src/localdb/rekordbox/anlz-parsers';
-import {
-  create2EXFile,
-  createPWV6Section,
-  createPWV7Section,
-  createPWVCSection,
-  SectionTags,
-} from './fixtures/anlz-fixtures';
+
+import {create2EXFile, SectionTags} from './fixtures/anlz-fixtures';
 
 // ============================================================================
 // Helper: Manual binary section parser
@@ -62,7 +57,7 @@ function parseAnlzSections(buffer: Buffer): ParsedSection[] {
 
       sections.push({
         fourcc,
-        body: { lenEntries, entries },
+        body: {lenEntries, entries},
       });
     } else if (fourcc === SectionTags.WAVE_HD) {
       // PWV7: len_entry_bytes(4) + len_entries(4) + unknown(4) + entries (same as PWV5)
@@ -74,7 +69,7 @@ function parseAnlzSections(buffer: Buffer): ParsedSection[] {
 
       sections.push({
         fourcc,
-        body: { lenEntries, entries },
+        body: {lenEntries, entries},
       });
     } else if (fourcc === SectionTags.VOCAL_CONFIG) {
       // PWVC: unknown(2) + threshold_low(2) + threshold_mid(2) + threshold_high(2)
@@ -84,7 +79,7 @@ function parseAnlzSections(buffer: Buffer): ParsedSection[] {
 
       sections.push({
         fourcc,
-        body: { thresholdLow, thresholdMid, thresholdHigh },
+        body: {thresholdLow, thresholdMid, thresholdHigh},
       });
     }
 
@@ -102,7 +97,7 @@ function parseAnlzSections(buffer: Buffer): ParsedSection[] {
 function convertPWV6ToBands(
   data: Uint8Array,
   numEntries: number
-): { low: number[]; mid: number[]; high: number[] } {
+): {low: number[]; mid: number[]; high: number[]} {
   const low = new Array<number>(numEntries);
   const mid = new Array<number>(numEntries);
   const high = new Array<number>(numEntries);
@@ -114,7 +109,7 @@ function convertPWV6ToBands(
     high[i] = data[offset + 2] / 255;
   }
 
-  return { low, mid, high };
+  return {low, mid, high};
 }
 
 describe('.2EX Integration Tests', () => {
@@ -125,11 +120,13 @@ describe('.2EX Integration Tests', () => {
     it('parses PWV6 from binary fixture end-to-end', () => {
       const inputData = new Uint8Array([255, 0, 128, 0, 255, 64, 100, 100, 100]);
       const file = create2EXFile({
-        pwv6: { numEntries: 3, data: inputData },
+        pwv6: {numEntries: 3, data: inputData},
       });
 
       const sections = parseAnlzSections(file);
-      const pwv6Section = sections.find(s => s.fourcc === SectionTags.WAVE_COLOR_3CHANNEL);
+      const pwv6Section = sections.find(
+        s => s.fourcc === SectionTags.WAVE_COLOR_3CHANNEL
+      );
       expect(pwv6Section).toBeDefined();
 
       const result = makeWaveform3BandPreview(pwv6Section!);
@@ -140,7 +137,7 @@ describe('.2EX Integration Tests', () => {
     it('parses PWV7 from binary fixture end-to-end', () => {
       const inputData = new Uint8Array([10, 20, 30, 40, 50, 60]);
       const file = create2EXFile({
-        pwv7: { numEntries: 2, data: inputData },
+        pwv7: {numEntries: 2, data: inputData},
       });
 
       const sections = parseAnlzSections(file);
@@ -154,7 +151,7 @@ describe('.2EX Integration Tests', () => {
 
     it('parses PWVC from binary fixture end-to-end', () => {
       const file = create2EXFile({
-        pwvc: { thresholdLow: 256, thresholdMid: 1024, thresholdHigh: 4096 },
+        pwvc: {thresholdLow: 256, thresholdMid: 1024, thresholdHigh: 4096},
       });
 
       const sections = parseAnlzSections(file);
@@ -172,9 +169,9 @@ describe('.2EX Integration Tests', () => {
       const pwv7Data = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80, 90]);
 
       const file = create2EXFile({
-        pwv6: { numEntries: 2, data: pwv6Data },
-        pwv7: { numEntries: 3, data: pwv7Data },
-        pwvc: { thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90 },
+        pwv6: {numEntries: 2, data: pwv6Data},
+        pwv7: {numEntries: 3, data: pwv7Data},
+        pwvc: {thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90},
       });
 
       const sections = parseAnlzSections(file);
@@ -210,7 +207,7 @@ describe('.2EX Integration Tests', () => {
   describe('partial .2EX files', () => {
     it('parses file with only PWV6', () => {
       const file = create2EXFile({
-        pwv6: { numEntries: 100 },
+        pwv6: {numEntries: 100},
       });
 
       const sections = parseAnlzSections(file);
@@ -223,7 +220,7 @@ describe('.2EX Integration Tests', () => {
 
     it('parses file with only PWVC', () => {
       const file = create2EXFile({
-        pwvc: { thresholdLow: 5, thresholdMid: 25, thresholdHigh: 75 },
+        pwvc: {thresholdLow: 5, thresholdMid: 25, thresholdHigh: 75},
       });
 
       const sections = parseAnlzSections(file);
@@ -236,8 +233,8 @@ describe('.2EX Integration Tests', () => {
 
     it('parses file with PWV6 and PWVC but no PWV7', () => {
       const file = create2EXFile({
-        pwv6: { numEntries: 50 },
-        pwvc: { thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90 },
+        pwv6: {numEntries: 50},
+        pwvc: {thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90},
       });
 
       const sections = parseAnlzSections(file);
@@ -265,7 +262,7 @@ describe('.2EX Integration Tests', () => {
         data[i] = i % 256;
       }
 
-      const file = create2EXFile({ pwv6: { numEntries, data } });
+      const file = create2EXFile({pwv6: {numEntries, data}});
       const sections = parseAnlzSections(file);
       const result = makeWaveform3BandPreview(sections[0]);
 
@@ -281,12 +278,12 @@ describe('.2EX Integration Tests', () => {
       for (let i = 0; i < numEntries; i++) {
         const progress = i / numEntries;
         const amplitude = Math.sin(progress * Math.PI); // bell curve
-        data[i * 3] = Math.floor(amplitude * 200);       // low
-        data[i * 3 + 1] = Math.floor(amplitude * 150);   // mid
-        data[i * 3 + 2] = Math.floor(amplitude * 100);   // high
+        data[i * 3] = Math.floor(amplitude * 200); // low
+        data[i * 3 + 1] = Math.floor(amplitude * 150); // mid
+        data[i * 3 + 2] = Math.floor(amplitude * 100); // high
       }
 
-      const file = create2EXFile({ pwv6: { numEntries, data } });
+      const file = create2EXFile({pwv6: {numEntries, data}});
       const sections = parseAnlzSections(file);
       const result = makeWaveform3BandPreview(sections[0]);
 
@@ -306,7 +303,7 @@ describe('.2EX Integration Tests', () => {
       }
 
       const file = create2EXFile({
-        pwv7: { numEntries, data },
+        pwv7: {numEntries, data},
       });
       const sections = parseAnlzSections(file);
       const result = makeWaveform3BandDetail(sections[0]);
@@ -330,12 +327,12 @@ describe('.2EX Integration Tests', () => {
       const data = new Uint8Array([255, 0, 128, 0, 255, 64]);
       const bands = convertPWV6ToBands(data, 2);
 
-      expect(bands.low[0]).toBeCloseTo(1.0);      // 255/255
-      expect(bands.mid[0]).toBeCloseTo(0.0);       // 0/255
+      expect(bands.low[0]).toBeCloseTo(1.0); // 255/255
+      expect(bands.mid[0]).toBeCloseTo(0.0); // 0/255
       expect(bands.high[0]).toBeCloseTo(128 / 255); // ~0.502
 
-      expect(bands.low[1]).toBeCloseTo(0.0);       // 0/255
-      expect(bands.mid[1]).toBeCloseTo(1.0);       // 255/255
+      expect(bands.low[1]).toBeCloseTo(0.0); // 0/255
+      expect(bands.mid[1]).toBeCloseTo(1.0); // 255/255
       expect(bands.high[1]).toBeCloseTo(64 / 255); // ~0.251
     });
 
@@ -402,12 +399,18 @@ describe('.2EX Integration Tests', () => {
     it('full pipeline: binary fixture → parse → convert to bands', () => {
       // Known input: 3 entries with specific band values
       const inputData = new Uint8Array([
-        255, 128, 0,     // Entry 0: loud low, medium mid, silent high
-        0, 0, 255,       // Entry 1: silent low/mid, loud high
-        128, 128, 128,   // Entry 2: equal bands
+        255,
+        128,
+        0, // Entry 0: loud low, medium mid, silent high
+        0,
+        0,
+        255, // Entry 1: silent low/mid, loud high
+        128,
+        128,
+        128, // Entry 2: equal bands
       ]);
 
-      const file = create2EXFile({ pwv6: { numEntries: 3, data: inputData } });
+      const file = create2EXFile({pwv6: {numEntries: 3, data: inputData}});
       const sections = parseAnlzSections(file);
       const preview = makeWaveform3BandPreview(sections[0]);
       const bands = convertPWV6ToBands(preview.data, preview.numEntries);
@@ -435,7 +438,7 @@ describe('.2EX Integration Tests', () => {
   describe('AnalysisDataPayload shape', () => {
     it('waveform3BandPreview converts to expected payload shape', () => {
       const inputData = new Uint8Array([200, 100, 50, 100, 200, 150]);
-      const file = create2EXFile({ pwv6: { numEntries: 2, data: inputData } });
+      const file = create2EXFile({pwv6: {numEntries: 2, data: inputData}});
       const sections = parseAnlzSections(file);
       const preview = makeWaveform3BandPreview(sections[0]);
       const bands = convertPWV6ToBands(preview.data, preview.numEntries);
@@ -457,7 +460,7 @@ describe('.2EX Integration Tests', () => {
 
     it('vocalConfig converts to expected payload shape', () => {
       const file = create2EXFile({
-        pwvc: { thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90 },
+        pwvc: {thresholdLow: 10, thresholdMid: 50, thresholdHigh: 90},
       });
       const sections = parseAnlzSections(file);
       const vocal = makeVocalConfig(sections[0]);
@@ -480,8 +483,12 @@ describe('.2EX Integration Tests', () => {
     it('null is a valid value when .2EX file is missing', () => {
       // Simulating what happens when .2EX load fails (.catch(() => null))
       const twoxResult = null as {
-        waveform3BandPreview: { numEntries: number; data: Uint8Array } | null;
-        vocalConfig: { thresholdLow: number; thresholdMid: number; thresholdHigh: number } | null;
+        waveform3BandPreview: {numEntries: number; data: Uint8Array} | null;
+        vocalConfig: {
+          thresholdLow: number;
+          thresholdMid: number;
+          thresholdHigh: number;
+        } | null;
       } | null;
       const waveform3BandPreview = twoxResult?.waveform3BandPreview ?? null;
       const vocalConfig = twoxResult?.vocalConfig ?? null;

--- a/tests/localdb/anlz-parsers-2ex.spec.ts
+++ b/tests/localdb/anlz-parsers-2ex.spec.ts
@@ -7,9 +7,9 @@
  */
 
 import {
-  makeWaveform3BandPreview,
-  makeWaveform3BandDetail,
   makeVocalConfig,
+  makeWaveform3BandDetail,
+  makeWaveform3BandPreview,
 } from 'src/localdb/rekordbox/anlz-parsers';
 
 describe('.2EX Parser Functions', () => {
@@ -57,13 +57,13 @@ describe('.2EX Parser Functions', () => {
 
       // Entry 1
       expect(result.data[0]).toBe(255); // low
-      expect(result.data[1]).toBe(0);   // mid
+      expect(result.data[1]).toBe(0); // mid
       expect(result.data[2]).toBe(128); // high
 
       // Entry 2
-      expect(result.data[3]).toBe(0);   // low
+      expect(result.data[3]).toBe(0); // low
       expect(result.data[4]).toBe(255); // mid
-      expect(result.data[5]).toBe(64);  // high
+      expect(result.data[5]).toBe(64); // high
 
       // Entry 3
       expect(result.data[6]).toBe(100);
@@ -79,7 +79,7 @@ describe('.2EX Parser Functions', () => {
       }
 
       const kaitaiSection = {
-        body: { lenEntries: numEntries, entries },
+        body: {lenEntries: numEntries, entries},
       };
 
       const result = makeWaveform3BandPreview(kaitaiSection);
@@ -118,7 +118,7 @@ describe('.2EX Parser Functions', () => {
     it('creates an independent copy of the data', () => {
       const entries = new Uint8Array([10, 20, 30]);
       const kaitaiSection = {
-        body: { lenEntries: 1, entries },
+        body: {lenEntries: 1, entries},
       };
 
       const result = makeWaveform3BandPreview(kaitaiSection);
@@ -180,7 +180,7 @@ describe('.2EX Parser Functions', () => {
       }
 
       const kaitaiSection = {
-        body: { lenEntries: numEntries, entries },
+        body: {lenEntries: numEntries, entries},
       };
 
       const result = makeWaveform3BandDetail(kaitaiSection);
@@ -204,7 +204,7 @@ describe('.2EX Parser Functions', () => {
     it('creates an independent copy of the data', () => {
       const entries = new Uint8Array([10, 20, 30]);
       const kaitaiSection = {
-        body: { lenEntries: 1, entries },
+        body: {lenEntries: 1, entries},
       };
 
       const result = makeWaveform3BandDetail(kaitaiSection);

--- a/tests/mixstatus/index.spec.ts
+++ b/tests/mixstatus/index.spec.ts
@@ -600,4 +600,96 @@ describe('mixstatus processor', () => {
 
     expect(npHandler).toBeCalledWith(oc({deviceId: 2, trackId: 234}));
   });
+
+  // Regression: cue-juggling on the master deck (common for House/Techno DJs)
+  // previously caused duplicate History entries because the Cued state drops
+  // the deck from livePlayers and the next Playing transition re-emits.
+  it('FollowsMaster: does not re-emit nowPlaying when master deck cues then plays same track', () => {
+    processor.configure({
+      mode: MixstatusMode.FollowsMaster,
+      useOnAirStatus: false,
+    });
+
+    const npHandler = jest.fn();
+    processor.on('nowPlaying', npHandler);
+
+    feedState(1, {
+      trackId: 123,
+      isMaster: true,
+      playState: CDJStatus.PlayState.Playing,
+    });
+    expect(npHandler).toHaveBeenCalledTimes(1);
+
+    feedState(1, {playState: CDJStatus.PlayState.Cued});
+    feedState(1, {playState: CDJStatus.PlayState.Playing});
+
+    expect(npHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('FollowsMaster: does not re-emit when master deck transitions Loading then plays same track', () => {
+    processor.configure({
+      mode: MixstatusMode.FollowsMaster,
+      useOnAirStatus: false,
+    });
+
+    const npHandler = jest.fn();
+    processor.on('nowPlaying', npHandler);
+
+    feedState(1, {
+      trackId: 123,
+      isMaster: true,
+      playState: CDJStatus.PlayState.Playing,
+    });
+    expect(npHandler).toHaveBeenCalledTimes(1);
+
+    feedState(1, {playState: CDJStatus.PlayState.Loading});
+    feedState(1, {playState: CDJStatus.PlayState.Cued});
+    feedState(1, {playState: CDJStatus.PlayState.Playing});
+
+    expect(npHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('FollowsMaster: emits a new nowPlaying when a different track is loaded on the master deck', () => {
+    processor.configure({
+      mode: MixstatusMode.FollowsMaster,
+      useOnAirStatus: false,
+    });
+
+    const npHandler = jest.fn();
+    processor.on('nowPlaying', npHandler);
+
+    feedState(1, {
+      trackId: 123,
+      isMaster: true,
+      playState: CDJStatus.PlayState.Playing,
+    });
+    expect(npHandler).toHaveBeenCalledTimes(1);
+
+    feedState(1, {playState: CDJStatus.PlayState.Cued});
+    feedState(1, {trackId: 456, playState: CDJStatus.PlayState.Loading});
+    feedState(1, {playState: CDJStatus.PlayState.Cued});
+    feedState(1, {playState: CDJStatus.PlayState.Playing});
+
+    expect(npHandler).toHaveBeenCalledTimes(2);
+    expect(npHandler).toHaveBeenLastCalledWith(oc({deviceId: 1, trackId: 456}));
+  });
+
+  it('does not re-emit nowPlaying when a deck cues and replays the same track in SmartTiming mode', () => {
+    processor.configure({useOnAirStatus: false});
+
+    const npHandler = jest.fn();
+    processor.on('nowPlaying', npHandler);
+
+    feedState(1, {
+      trackId: 123,
+      playState: CDJStatus.PlayState.Playing,
+    });
+    expect(npHandler).toHaveBeenCalledTimes(1);
+
+    // Cue and resume the same track
+    feedState(1, {playState: CDJStatus.PlayState.Cued});
+    feedState(1, {playState: CDJStatus.PlayState.Playing});
+
+    expect(npHandler).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/nfs/path.spec.ts
+++ b/tests/nfs/path.spec.ts
@@ -1,5 +1,5 @@
-import {MediaSlot} from 'src/types';
 import {parseWindowsPath, resolveNfsPath} from 'src/nfs';
+import {MediaSlot} from 'src/types';
 
 describe('parseWindowsPath', () => {
   it('parses a Windows path with backslashes', () => {
@@ -73,10 +73,7 @@ describe('resolveNfsPath', () => {
   });
 
   it('extracts mount path from Windows file path for RB slot', () => {
-    const result = resolveNfsPath(
-      MediaSlot.RB,
-      'C:\\Users\\chris\\Music\\track.mp3'
-    );
+    const result = resolveNfsPath(MediaSlot.RB, 'C:\\Users\\chris\\Music\\track.mp3');
     expect(result).toEqual({
       mountPath: '/C/',
       nfsPath: 'Users/chris/Music/track.mp3',
@@ -84,10 +81,7 @@ describe('resolveNfsPath', () => {
   });
 
   it('handles RB slot with forward-slash Windows path', () => {
-    const result = resolveNfsPath(
-      MediaSlot.RB,
-      'D:/Music/rekordbox/track.wav'
-    );
+    const result = resolveNfsPath(MediaSlot.RB, 'D:/Music/rekordbox/track.wav');
     expect(result).toEqual({
       mountPath: '/D/',
       nfsPath: 'Music/rekordbox/track.wav',
@@ -95,10 +89,7 @@ describe('resolveNfsPath', () => {
   });
 
   it('extracts mount path from macOS file path for RB slot', () => {
-    const result = resolveNfsPath(
-      MediaSlot.RB,
-      '/Users/chris/Music/track.mp3'
-    );
+    const result = resolveNfsPath(MediaSlot.RB, '/Users/chris/Music/track.mp3');
     expect(result).toEqual({
       mountPath: '/',
       nfsPath: 'Users/chris/Music/track.mp3',

--- a/tests/passive/alphatheta.spec.ts
+++ b/tests/passive/alphatheta.spec.ts
@@ -1,8 +1,8 @@
-import {type NetworkInterfaceInfo, type NetworkInterfaceInfoIPv4} from 'os';
+import {type NetworkInterfaceInfoIPv4} from 'os';
 
 import {
-  findAlphaThetaInterface,
   findAllAlphaThetaInterfaces,
+  findAlphaThetaInterface,
   getArpCacheForInterface,
 } from 'src/passive/alphatheta';
 
@@ -14,7 +14,9 @@ import {execSync} from 'child_process';
 import {networkInterfaces} from 'os';
 
 const execSyncMock = execSync as jest.MockedFunction<typeof execSync>;
-const networkInterfacesMock = networkInterfaces as jest.MockedFunction<typeof networkInterfaces>;
+const networkInterfacesMock = networkInterfaces as jest.MockedFunction<
+  typeof networkInterfaces
+>;
 
 // Helper to create mock NetworkInterfaceInfo
 function mockNetworkInterfaceInfo(

--- a/tests/passive/pcap-adapter.spec.ts
+++ b/tests/passive/pcap-adapter.spec.ts
@@ -4,35 +4,41 @@ import {type NetworkInterfaceInfoIPv4} from 'os';
 // We test it indirectly through PcapAdapter.start(), but we can also test the
 // resolution logic by mocking os.networkInterfaces and the cap module.
 
-// Mock os and cap before importing
+// Mock os and cap before importing.
+// `cap` is in optionalDependencies (requires libpcap-dev on Linux / Npcap on
+// Windows) and may not be installed in CI, so mock it as a virtual module.
 jest.mock('os');
-jest.mock('cap', () => {
-  // Return a mock that tracks open() calls so we can verify the device name
-  const mockCap = {
-    open: jest.fn(),
-    on: jest.fn(),
-    close: jest.fn(),
-    setMinBytes: jest.fn(),
-  };
-  return {
-    Cap: Object.assign(
-      jest.fn(() => mockCap),
-      {
-        deviceList: jest.fn(),
-        __mockInstance: mockCap,
-      }
-    ),
-    decoders: {
-      PROTOCOL: {
-        ETHERNET: {IPV4: 0x0800},
-        IP: {UDP: 17},
+jest.mock(
+  'cap',
+  () => {
+    // Return a mock that tracks open() calls so we can verify the device name
+    const mockCap = {
+      open: jest.fn(),
+      on: jest.fn(),
+      close: jest.fn(),
+      setMinBytes: jest.fn(),
+    };
+    return {
+      Cap: Object.assign(
+        jest.fn(() => mockCap),
+        {
+          deviceList: jest.fn(),
+          __mockInstance: mockCap,
+        }
+      ),
+      decoders: {
+        PROTOCOL: {
+          ETHERNET: {IPV4: 0x0800},
+          IP: {UDP: 17},
+        },
+        Ethernet: jest.fn(),
+        IPV4: jest.fn(),
+        UDP: jest.fn(),
       },
-      Ethernet: jest.fn(),
-      IPV4: jest.fn(),
-      UDP: jest.fn(),
-    },
-  };
-});
+    };
+  },
+  {virtual: true}
+);
 
 import {networkInterfaces} from 'os';
 

--- a/tests/passive/pcap-adapter.spec.ts
+++ b/tests/passive/pcap-adapter.spec.ts
@@ -35,9 +35,12 @@ jest.mock('cap', () => {
 });
 
 import {networkInterfaces} from 'os';
+
 import {PcapAdapter} from 'src/passive/pcap-adapter';
 
-const networkInterfacesMock = networkInterfaces as jest.MockedFunction<typeof networkInterfaces>;
+const networkInterfacesMock = networkInterfaces as jest.MockedFunction<
+  typeof networkInterfaces
+>;
 
 // Access the mocked cap module
 // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Summary

- Stop the `MixstatusProcessor` from emitting a second `nowPlaying` event when the same track is replayed on the same deck (cue-juggle scenarios)
- Track the last-emitted `trackId` per device and short-circuit `#promotePlayer` when the next promotion would duplicate it
- A different `trackId` on the same deck still emits as before

## Why

Pressing **CUE** on the master deck transitions the deck through `Cued` — one of the `stoppingStates` — which drops it from `livePlayers`. The next `Playing` transition then re-runs `#promotePlayer`, re-emitting `nowPlaying` for the same `trackId`. House/Techno DJs commonly cue-juggle mid-track, so every cue press produced a duplicate downstream event (e.g. duplicate History entries when recording with NowPlaying3 from XDJ-XZ via ProDJ Link).

## Test plan

- `yarn test tests/mixstatus` — 29 tests, including 4 new regression cases covering cue/play, Loading/cue/play, mid-track-load track-change, and the same scenario in `SmartTiming` mode
- All existing mixstatus tests continue to pass

Fixes the user-visible bug reported in [NP3-229](https://triodeofficial.atlassian.net/browse/NP3-229).

[NP3-229]: https://triodeofficial.atlassian.net/browse/NP3-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ